### PR TITLE
#22 show current version on landing page

### DIFF
--- a/_includes/_home/projectHeader.html
+++ b/_includes/_home/projectHeader.html
@@ -10,6 +10,7 @@
             {% include _icons/github.svg %}
 	    </a>
           </span>
+          <span class="projectMeta__item latestRelease" data-releases-url="{{ repository.releases_url }}"></span>
           <span class="projectMeta__item star">
             {% include _icons/star.svg %}
             {{ repository.stargazers_count }}

--- a/_sass/pages/_projectHeader.scss
+++ b/_sass/pages/_projectHeader.scss
@@ -172,6 +172,13 @@
     &.twitter {
       @include size('padding-left', 5px);
     }
+
+    &.latestRelease {
+      @include size('padding-left', 0px);
+      a {
+        @include size('margin-left', 5px);
+      }
+    }
   }
 
   .projectMeta ~ p:last-of-type {

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -59,6 +59,21 @@ var TSOS = TSOS || {};
     breakpoint : function () {
       var breakpoint = window.getComputedStyle(document.querySelector('body'), ':before').getPropertyValue('content').replace(/\"/g, '');
       return breakpoint;
+    },
+
+    initLatestRelease : function() {
+      var latestEl = $('.latestRelease');
+      var latestUrl = latestEl.data('releases-url').replace('{/id}', '/latest');
+
+      $.ajax(latestUrl).then(function(resp) {
+        latestEl.empty().append(
+          $('<a>', {
+            target: '_blank',
+            href: resp.html_url,
+            text: resp.tag_name,
+          })
+        )
+      });
     }
   };
 
@@ -180,5 +195,6 @@ var TSOS = TSOS || {};
   // -----------------------------
   $(function() {
     APP.helpers.initComponents($('body'));
+    APP.helpers.initLatestRelease();
   });
 }(window, jQuery, TSOS, undefined));


### PR DESCRIPTION
Tried to get tag and url from jekyll-github-metadata plugin but could not get it working, so i'm doing it via ajax call.

![image](https://user-images.githubusercontent.com/743617/32950177-bb6fadfe-cba5-11e7-9bee-75cc96226b83.png)

github icon -> links to repository
release tag -> links to release on github