### PR TITLE
#35 fix first block of text missing on narrow window

### DIFF
--- a/_includes/_home/projectHeader.html
+++ b/_includes/_home/projectHeader.html
@@ -27,19 +27,10 @@
         </span>
         {% endif %}
       </div>
-      <div class="projectHeader--optional projectHeader__text">{{ include.project.text | markdownify }}</div>
+      <div class="projectHeader__text">{{ include.project.text | markdownify }}</div>
     </div>
   </div>
-  {% if include.project.header %}
-    {% if page.order == 1 %}
-    <div class="projectHeader__section projectHeader--aside js--postNav">
-    {% else %}
-    <div class="projectHeader__section projectHeader--optional projectHeader--aside">
-    {% endif %}
-  {% else %}
-  <div class="projectHeader__section projectHeader--optional projectHeader--aside projectHeader--col">
-  {% endif %}
-
+  <div class="projectHeader__section projectHeader--aside">
     {% for section in include.project.header %}
     <div class="projectHeader__item projectHeader__section__inner">
       <header>

--- a/_sass/pages/_projectHeader.scss
+++ b/_sass/pages/_projectHeader.scss
@@ -20,6 +20,12 @@
   &__text {
     @extend %p;
 
+    padding: rem(10px) rem(30px);
+
+    @include breakpoint(desktop) {
+      padding: 0;
+    }
+
     a {
       @include underlined($color-white);
     }


### PR DESCRIPTION
Now it should be ok both on mobile and desktop

Order of page elements on mobile:
- header with wordmark
- github/social bar
- BeakerX is collection of kernels...
- Install BeakerX
- Run with Docker
- Subpages navigation
- Subpage content
- Footer

