### PR TITLE
fixed "notebooks" link under "tutorials and examples" in documentation.md

### DIFF
--- a/_home_subpages/documentation.md
+++ b/_home_subpages/documentation.md
@@ -8,7 +8,7 @@ order: 3
 ### Tutorials and Examples
 
 Most of the documentation consists of
-[notebooks](http://nbviewer.jupyter.org/github/twosigma/beakerx/blob/master/doc/StartHere.ipynb)
+[notebooks](http://nbviewer.jupyter.org/github/twosigma/beakerx/blob/master/StartHere.ipynb)
 that show BeakerX's kernels and widgets in action.
 
 ### Installation with Conda


### PR DESCRIPTION
the link was broken, took out /doc/ so it should work now! :)